### PR TITLE
Updating plugin to UE 4.21

### DIFF
--- a/Source/UTFPublisher/UTFPublisher.Build.cs
+++ b/Source/UTFPublisher/UTFPublisher.Build.cs
@@ -1,6 +1,7 @@
 // Copyright 2017, Institute for Artificial Intelligence - University of Bremen
 // Author: Andrei Haidu (http://haidu.eu)
 
+using System.IO;
 using UnrealBuildTool;
 
 public class UTFPublisher : ModuleRules
@@ -9,21 +10,8 @@ public class UTFPublisher : ModuleRules
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 		
-		PublicIncludePaths.AddRange(
-			new string[] {
-				"UTFPublisher/Public"
-				// ... add public include paths required here ...
-			}
-			);
-				
-		
-		PrivateIncludePaths.AddRange(
-			new string[] {
-				"UTFPublisher/Private",
-				// ... add other private include paths required here ...
-			}
-			);
-			
+        	PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+        	PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 		
 		PublicDependencyModuleNames.AddRange(
 			new string[]


### PR DESCRIPTION
Updating plugin according to change 2.6.3.e on https://www.unrealengine.com/en-US/marketplace-guidelines

Plugins being built against engine versions 4.20 onward that need to include files from their own plugin directory must add those include paths using the ModuleDirectory property in their .build.cs. 
If _using System.IO;_ exists at the top of the .build.cs, Publishers can use the following syntax where "MyFolder" is the name of the directory under the current module they'd like to include:
PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "MyFolder"));